### PR TITLE
add: #1 Pass a number as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ It generates a binary under `./target/debug/seven_segments`. You can execute
 the binary directly or use cargo again:
 
 ```console
-$ cargo run
+$ cargo run 42
+42
 ```
 
 In this case, cargo makes sure the binary is up-to-date with the latest version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,52 @@
+pub fn parse_number(string: &str) -> Result<i32, std::num::ParseIntError> {
+    string.trim().parse()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_number_accepts_number() {
+        let string_number = "42";
+        let expected_number = 42;
+
+        let resulting_number = parse_number(string_number).unwrap();
+
+        assert_eq!(resulting_number, expected_number);
+    }
+
+    #[test]
+    fn parse_number_accepts_surrounding_spaces() {
+        let string_number = "   42  ";
+        let expected_number = 42;
+
+        let resulting_number = parse_number(string_number).unwrap();
+
+        assert_eq!(resulting_number, expected_number);
+    }
+
+    #[test]
+    fn parse_number_fails_when_passing_a_non_parsable_string() {
+        let string_number = "foo42";
+
+        let resulting_number = parse_number(string_number);
+
+        assert!(
+            resulting_number.is_err(),
+            format!("{} is supposed to not be parsable", string_number)
+        );
+    }
+
+    #[test]
+    fn parse_number_fails_when_passing_an_empty_string() {
+        let string_number = "";
+
+        let resulting_number = parse_number(string_number);
+
+        assert!(
+            resulting_number.is_err(),
+            "Empty string is supposed to not be parsable"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,28 @@
+extern crate seven_segments;
+
+use std::env;
+use std::process;
+
+use seven_segments::parse_number;
+
 fn main() {
-    println!("Hello, world!");
+    match run() {
+        Ok(number) => println!("{}", number),
+        Err(e) => {
+            println!("{}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn run() -> Result<i32, &'static str> {
+    let arg1 = match env::args().nth(1) {
+        Some(arg) => arg,
+        None => return Err("Command expects at least one argument"),
+    };
+
+    match parse_number(&arg1) {
+        Ok(number) => Ok(number),
+        Err(_) => Err("Command expects the argument to be a number"),
+    }
 }


### PR DESCRIPTION
Closes #1 

Changes proposed in this pull request:

- Add support for an argument to the cli
- Parse the argument and display it if it is a number
- Display an error if there are no arguments or if argument is not a number

Pull request checklist:

- [x] branch is rebased on `master`
- [x] proper commit messages
- [x] proper coding style
- [x] code is properly tested
- [x] changes are documented
- [x] document breaking changes in [changelog](https://github.com/marienfressinaud/seven_segments/blob/master/CHANGELOG.md) (optional)
