### PR TITLE
add: #2 Output digits on 7-segments display

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ the binary directly or use cargo again:
 
 ```console
 $ cargo run 42
-42
+     _ 
+|_|  _|
+  | |_ 
 ```
 
 In this case, cargo makes sure the binary is up-to-date with the latest version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,38 @@ pub fn parse_number(string: &str) -> Result<i32, std::num::ParseIntError> {
     string.trim().parse()
 }
 
+pub fn split_into_digits(number: i32) -> Vec<u8> {
+    if number == 0 {
+        return vec![0];
+    }
+
+    let mut digits: Vec<u8> = Vec::new();
+    let mut number = number;
+    while number != 0 {
+        digits.insert(0, (number % 10) as u8);
+        number = number / 10;
+    }
+    digits
+}
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+const DIGIT_PATTERNS: &'static [&'static [&'static str]] = &[
+    &[" _ ", "   ", " _ ", " _ ", "   ", " _ ", " _ ", " _ ", " _ ", " _ "],
+    &["| |", "  |", " _|", " _|", "|_|", "|_ ", "|_ ", "  |", "|_|", "|_|"],
+    &["|_|", "  |", "|_ ", " _|", "  |", " _|", "|_|", "  |", "|_|", " _|"],
+];
+
+pub fn render_digits(digits: &Vec<u8>, output: &mut String) {
+    for position in 0..=2 {
+        let rendered_position = digits
+            .iter()
+            .map(|digit| DIGIT_PATTERNS[position][*digit as usize])
+            .collect::<Vec<&'static str>>()
+            .join(" ");
+        output.push_str(&format!("{}\n", rendered_position));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,5 +80,55 @@ mod tests {
             resulting_number.is_err(),
             "Empty string is supposed to not be parsable"
         );
+    }
+
+    #[test]
+    fn split_into_digits_returns_vec_of_digits() {
+        let number = 42;
+        let expected_digits = [4, 2];
+
+        let resulting_digits = split_into_digits(number);
+
+        assert_eq!(resulting_digits, expected_digits);
+    }
+
+    #[test]
+    fn split_into_digits_accepts_zero_value() {
+        let number = 0;
+        let expected_digits = [0];
+
+        let resulting_digits = split_into_digits(number);
+
+        assert_eq!(resulting_digits, expected_digits);
+    }
+
+    #[test]
+    fn render_digits_returns_string_representing_7_segments_output() {
+        let digits = vec![3];
+        let expected_output = r#"
+ _ 
+ _|
+ _|
+"#.trim_left_matches('\n');
+
+        let mut resulting_output = String::new();
+        render_digits(&digits, &mut resulting_output);
+
+        assert_eq!(resulting_output, expected_output);
+    }
+
+    #[test]
+    fn render_digits_returns_digits_seperated_by_spaces() {
+        let digits = vec![4, 2];
+        let expected_output = r#"
+     _ 
+|_|  _|
+  | |_ 
+"#.trim_left_matches('\n');
+
+        let mut resulting_output = String::new();
+        render_digits(&digits, &mut resulting_output);
+
+        assert_eq!(resulting_output, expected_output);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,12 @@ extern crate seven_segments;
 use std::env;
 use std::process;
 
-use seven_segments::parse_number;
+use seven_segments::{parse_number, render_digits, split_into_digits};
 
 fn main() {
-    match run() {
-        Ok(number) => println!("{}", number),
+    let mut output = String::new();
+    match run(&mut output) {
+        Ok(_) => print!("{}", output),
         Err(e) => {
             println!("{}", e);
             process::exit(1);
@@ -15,14 +16,18 @@ fn main() {
     }
 }
 
-fn run() -> Result<i32, &'static str> {
+fn run(output: &mut String) -> Result<(), &'static str> {
     let arg1 = match env::args().nth(1) {
         Some(arg) => arg,
         None => return Err("Command expects at least one argument"),
     };
 
-    match parse_number(&arg1) {
-        Ok(number) => Ok(number),
-        Err(_) => Err("Command expects the argument to be a number"),
-    }
+    let number = match parse_number(&arg1) {
+        Ok(number) => number,
+        Err(_) => return Err("Command expects the argument to be a number"),
+    };
+
+    let digits = split_into_digits(number);
+    render_digits(&digits, output);
+    Ok(())
 }


### PR DESCRIPTION
Closes #2

Changes proposed in this pull request:

- Render numbers passed as arguments as a 7-segments output

Pull request checklist:

- [x] branch is rebased on `master`
- [x] proper commit messages
- [x] proper coding style
- [x] code is properly tested
- [x] changes are documented
- [x] document breaking changes in [changelog](https://github.com/marienfressinaud/seven_segments/blob/master/CHANGELOG.md) (optional)
