### PR TITLE
fix: #8 Fix numbers parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,15 @@ pub fn split_into_digits(number: i32) -> Vec<u8> {
     digits
 }
 
-pub fn parse_digits(string: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
-    let number = parse_number(string)?;
-    let digits = split_into_digits(number);
+pub fn parse_digits(string: &str) -> Result<Vec<u8>, &'static str> {
+    let mut digits: Vec<u8> = Vec::new();
+    for c in string.trim().chars() {
+        let digit = match c.to_digit(10) {
+            Some(d) => d,
+            None => return Err("parameter cannot be parsed as digits"),
+        };
+        digits.push(digit as u8);
+    }
     Ok(digits)
 }
 
@@ -141,15 +147,35 @@ mod tests {
     }
 
     #[test]
-    fn parse_digits_fails_when_passing_an_empty_string() {
+    fn parse_digits_accepts_empty_strings() {
         let string_number = "";
+        let expected_digits = [];
 
-        let resulting_digits = parse_digits(string_number);
+        let resulting_digits = parse_digits(string_number).unwrap();
 
-        assert!(
-            resulting_digits.is_err(),
-            "Empty string is supposed to not be parsable"
-        );
+        assert_eq!(resulting_digits, expected_digits);
+    }
+
+    #[test]
+    fn parse_digits_accepts_big_numbers() {
+        let string_number = "184467440737095516159";
+        let expected_digits = [
+            1, 8, 4, 4, 6, 7, 4, 4, 0, 7, 3, 7, 0, 9, 5, 5, 1, 6, 1, 5, 9,
+        ];
+
+        let resulting_digits = parse_digits(string_number).unwrap();
+
+        assert_eq!(resulting_digits, expected_digits);
+    }
+
+    #[test]
+    fn parse_digits_accepts_leading_zeros() {
+        let string_number = "0042";
+        let expected_digits = [0, 0, 4, 2];
+
+        let resulting_digits = parse_digits(string_number).unwrap();
+
+        assert_eq!(resulting_digits, expected_digits);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,12 @@ pub fn split_into_digits(number: i32) -> Vec<u8> {
     digits
 }
 
+pub fn parse_digits(string: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
+    let number = parse_number(string)?;
+    let digits = split_into_digits(number);
+    Ok(digits)
+}
+
 #[cfg_attr(rustfmt, rustfmt_skip)]
 const DIGIT_PATTERNS: &'static [&'static [&'static str]] = &[
     &[" _ ", "   ", " _ ", " _ ", "   ", " _ ", " _ ", " _ ", " _ ", " _ "],
@@ -100,6 +106,50 @@ mod tests {
         let resulting_digits = split_into_digits(number);
 
         assert_eq!(resulting_digits, expected_digits);
+    }
+
+    #[test]
+    fn parse_digits_accepts_number() {
+        let string_number = "42";
+        let expected_digits = [4, 2];
+
+        let resulting_digits = parse_digits(string_number).unwrap();
+
+        assert_eq!(resulting_digits, expected_digits);
+    }
+
+    #[test]
+    fn parse_digits_accepts_surrounding_spaces() {
+        let string_number = "   42  ";
+        let expected_digits = [4, 2];
+
+        let resulting_digits = parse_digits(string_number).unwrap();
+
+        assert_eq!(resulting_digits, expected_digits);
+    }
+
+    #[test]
+    fn parse_digits_fails_when_passing_a_non_parsable_string() {
+        let string_number = "foo42";
+
+        let resulting_digits = parse_digits(string_number);
+
+        assert!(
+            resulting_digits.is_err(),
+            format!("{} is supposed to not be parsable", string_number)
+        );
+    }
+
+    #[test]
+    fn parse_digits_fails_when_passing_an_empty_string() {
+        let string_number = "";
+
+        let resulting_digits = parse_digits(string_number);
+
+        assert!(
+            resulting_digits.is_err(),
+            "Empty string is supposed to not be parsable"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,3 @@
-pub fn parse_number(string: &str) -> Result<i32, std::num::ParseIntError> {
-    string.trim().parse()
-}
-
-pub fn split_into_digits(number: i32) -> Vec<u8> {
-    if number == 0 {
-        return vec![0];
-    }
-
-    let mut digits: Vec<u8> = Vec::new();
-    let mut number = number;
-    while number != 0 {
-        digits.insert(0, (number % 10) as u8);
-        number = number / 10;
-    }
-    digits
-}
-
 pub fn parse_digits(string: &str) -> Result<Vec<u8>, &'static str> {
     let mut digits: Vec<u8> = Vec::new();
     for c in string.trim().chars() {
@@ -49,70 +31,6 @@ pub fn render_digits(digits: &Vec<u8>, output: &mut String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_number_accepts_number() {
-        let string_number = "42";
-        let expected_number = 42;
-
-        let resulting_number = parse_number(string_number).unwrap();
-
-        assert_eq!(resulting_number, expected_number);
-    }
-
-    #[test]
-    fn parse_number_accepts_surrounding_spaces() {
-        let string_number = "   42  ";
-        let expected_number = 42;
-
-        let resulting_number = parse_number(string_number).unwrap();
-
-        assert_eq!(resulting_number, expected_number);
-    }
-
-    #[test]
-    fn parse_number_fails_when_passing_a_non_parsable_string() {
-        let string_number = "foo42";
-
-        let resulting_number = parse_number(string_number);
-
-        assert!(
-            resulting_number.is_err(),
-            format!("{} is supposed to not be parsable", string_number)
-        );
-    }
-
-    #[test]
-    fn parse_number_fails_when_passing_an_empty_string() {
-        let string_number = "";
-
-        let resulting_number = parse_number(string_number);
-
-        assert!(
-            resulting_number.is_err(),
-            "Empty string is supposed to not be parsable"
-        );
-    }
-
-    #[test]
-    fn split_into_digits_returns_vec_of_digits() {
-        let number = 42;
-        let expected_digits = [4, 2];
-
-        let resulting_digits = split_into_digits(number);
-
-        assert_eq!(resulting_digits, expected_digits);
-    }
-
-    #[test]
-    fn split_into_digits_accepts_zero_value() {
-        let number = 0;
-        let expected_digits = [0];
-
-        let resulting_digits = split_into_digits(number);
-
-        assert_eq!(resulting_digits, expected_digits);
-    }
 
     #[test]
     fn parse_digits_accepts_number() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate seven_segments;
 use std::env;
 use std::process;
 
-use seven_segments::{parse_number, render_digits, split_into_digits};
+use seven_segments::{parse_digits, render_digits};
 
 fn main() {
     let mut output = String::new();
@@ -22,12 +22,10 @@ fn run(output: &mut String) -> Result<(), &'static str> {
         None => return Err("Command expects at least one argument"),
     };
 
-    let number = match parse_number(&arg1) {
-        Ok(number) => number,
+    let digits = match parse_digits(&arg1) {
+        Ok(digits) => digits,
         Err(_) => return Err("Command expects the argument to be a number"),
     };
-
-    let digits = split_into_digits(number);
     render_digits(&digits, output);
     Ok(())
 }


### PR DESCRIPTION
Closes #8

Changes proposed in this pull request:

- Add a `parse_digits` function
- Parse and convert string character by character
- Remove `parse_number` and `split_into_digits` funcs

Pull request checklist:

- [x] branch is rebased on `master`
- [x] proper commit messages
- [x] proper coding style
- [x] code is properly tested
- [x] changes are documented
- [x] document breaking changes in [changelog](https://github.com/marienfressinaud/seven_segments/blob/master/CHANGELOG.md) (optional)
